### PR TITLE
Fixed math library linking issue

### DIFF
--- a/two-pass-assembler/README.md
+++ b/two-pass-assembler/README.md
@@ -26,6 +26,10 @@ To execute pass 2 execute the following command:
 Both pass-1 and pass-2 can be executed in one command:
 `gcc -o pass-1.exe pass-1.c utils.c && ./pass-1.exe && gcc -o pass-2.exe pass-2.c utils.c && ./pass-2.exe`
 
+There is a Linux-specific issue because the math library (libm) isn't linked by default. Use the following command to compile successfully:
+`gcc -o pass-2.exe pass-2.c utils.c -lm && ./pass-2.exe`
+
+
 `input.txt`, `OPTAB.txt` are written in this directory for reference.
 
 Pass 1 produces `intermediate.txt`, `SYMTAB.txt` and `program_length.txt` as outputs.


### PR DESCRIPTION
There is a Linux-specific issue because the math library (libm) isn't linked by default. Use the following command to compile successfully:
`gcc -o pass-2.exe pass-2.c utils.c -lm && ./pass-2.exe`

